### PR TITLE
Fix celery and config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,37 +25,16 @@ Quorum has four main different components:
 First off, the scrapers are implemented using the official APIs for each
 platform. As such, in order to use you will need the proper credentials.
 
-Also, you probably want to specify what accounts, pages, subreddits to scrape!
+Also, you need  to specify what accounts, pages, subreddits to scrape!
 
-So in the top level directory you should include all the above information in a
-file named `config.py`, which should look like this:
+In the top level directory run the command below.
+
 ```
-TWITTER = {                                                                     
-    'CONSUMER_KEY': 'xxxxxxxx',                                
-    'CONSUMER_SECRET': 'xxxxxxx',    
-    'ACCESS_TOKEN': 'xxxxxxxxxxx',       
-    'ACCESS_SECRET': 'xxxxxxxxxx',           
-}                                                                               
-FACEBOOK = {                                                                    
-    'APP_ID': 'xxxxxxxxxxxxxxx',                                               
-    'APP_SECRET': 'xxxxxxxxxxxx',                           
-}                                                                               
-REDDIT = {                                                                      
-    'CLIENT_ID': 'xxxxxxxxxxxx',                                              
-    'CLIENT_SECRET': 'xxxxxxxxxxxxxxx',                             
-    'USER_AGENT': 'User-Agent: web:com.xxxxxxx.xxxxxx:v1.0 (by /u/xxxxxxxx)',
-}                                                                               
-                                                                                
-twitterUsernames = [                                                            
-    'screen_name'                                                                   
-]                     
-fbPages = [                                                                     
-    'page'                                                                  
-]                                                                               
-subreddits = [                                                                  
-    'subreddit'                                                                
-]               
+  $ cp config_example.py config.py
+
 ```
+
+Edit the config.py with the needed service credentials.
 
 To spin up your own version of quorum you can run the following command at the
 top level directory of this project:

--- a/config_example.py
+++ b/config_example.py
@@ -1,0 +1,25 @@
+TWITTER = {                                                                     
+    'CONSUMER_KEY': 'xxxxxxxx',                                
+    'CONSUMER_SECRET': 'xxxxxxx',    
+    'ACCESS_TOKEN': 'xxxxxxxxxxx',       
+    'ACCESS_SECRET': 'xxxxxxxxxx',           
+}                                                                               
+FACEBOOK = {                                                                    
+    'APP_ID': 'xxxxxxxxxxxxxxx',                                               
+    'APP_SECRET': 'xxxxxxxxxxxx',                           
+}                                                                               
+REDDIT = {                                                                      
+    'CLIENT_ID': 'xxxxxxxxxxxx',                                              
+    'CLIENT_SECRET': 'xxxxxxxxxxxxxxx',                             
+    'USER_AGENT': 'User-Agent: web:com.xxxxxxx.xxxxxx:v1.0 (by /u/xxxxxxxx)',
+}                                                                               
+                                                                                
+twitterUsernames = [                                                            
+    'screen_name'                                                                   
+]                     
+fbPages = [                                                                     
+    'page'                                                                  
+]                                                                               
+subreddits = [                                                                  
+    'subreddit'                                                                
+]               

--- a/start.sh
+++ b/start.sh
@@ -48,4 +48,4 @@ cd ../../
 # Start queue
 cd scheduler/
 ./start_app.sh |& tee ${logs}/build.out 
-../
+cd ../

--- a/start.sh
+++ b/start.sh
@@ -46,6 +46,6 @@ cd ../reddit/
 cd ../../
 
 # Start queue
-cd celery/
+cd scheduler/
 ./start_app.sh |& tee ${logs}/build.out 
-cd ../
+../

--- a/stop.sh
+++ b/stop.sh
@@ -6,26 +6,26 @@ clear
 set -x                                                                          
        
 # Stop queue
-cd celery/                                                                      
-sudo docker-compose down                                        
+cd scheduler/
+docker-compose down
 cd ../
 
 # Stop scrapers
 cd quorum/twitter
-sudo docker-compose down 
+docker-compose down
 cd ../facebook
-sudo docker-compose down
+docker-compose down
 cd ../reddit
-sudo docker-compose down
+docker-compose down
 cd ../../
 
 # stop DB
 cd storage
-sudo docker-compose down
+docker-compose down
 cd ../
 
 # Start Kafka server
 cd kafka/
-sudo docker-compose down 
+docker-compose down
 cd ../
 


### PR DESCRIPTION
- Removed celery startup and replaced it with scheduler
- added config_example.py and updated the readme

Things to consider:
Sudo is being used in the script for docker and depending on security/permission levels of the account running this should be removed and have the user added to the docker group.

Also, maybe instead of copying the config to each docker folder, have all the containers read from the base config.py file

